### PR TITLE
feat(webserver): Add a webserver mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Usage of csminify:
         Snapshot frequency - per second (default 0.5)
   -out path
         Output file path (default stdout)
+  -server true/false
+        Start a Webserver listening on Port 8080 instead. It accepts a demo as binary body. By setting the 
+        x-freq header, the minification can be configured. When setting 'server' to true, all other parameters
+        but 'httpPort' get ignored.
+  -httpPort number
+        Only gets considered when server is set to true. It can be used to change the default port of 8080. 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Usage of csminify:
   -out path
         Output file path (default stdout)
   -server true/false
-        Start a Webserver listening on Port 8080 instead. It accepts a demo as binary body. By setting the 
+        Start a Webserver listening on Port 8080 instead. The resulting API, listening on POST '/', accepts a demo as binary body. By setting the 
         x-freq header, the minification can be configured. When setting 'server' to true, all other parameters
         but 'httpPort' get ignored.
   -httpPort number

--- a/cmd/csminify/main.go
+++ b/cmd/csminify/main.go
@@ -141,7 +141,7 @@ func StreamToByte(stream io.Reader) []byte {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(stream)
 
-	if err == nil {
+	if err != nil {
 		return nil
 	}
 

--- a/cmd/csminify/main.go
+++ b/cmd/csminify/main.go
@@ -133,7 +133,7 @@ func HTTPHandler(w http.ResponseWriter, r *http.Request) {
 	err := min.MinifyTo(byteReader, freq, marshaller, w)
 
 	if err != nil {
-		log.Println("An Error occured when minifying")
+		log.Println("An Error occurred when minifying")
 	}
 }
 

--- a/cmd/csminify/main.go
+++ b/cmd/csminify/main.go
@@ -47,7 +47,6 @@ func main() {
 	outPath := *outPathPtr
 
 	if *webserver {
-		fmt.Println("orld")
 		log.Println("Started a WebServer")
 		http.HandleFunc("/", HTTPHandler)
 		log.Fatal(http.ListenAndServe(":"+strconv.Itoa(*httpPort), nil))
@@ -131,7 +130,11 @@ func HTTPHandler(w http.ResponseWriter, r *http.Request) {
 		return json.NewEncoder(w).Encode(replay)
 	}
 
-	min.MinifyTo(byteReader, freq, marshaller, w)
+	err := min.MinifyTo(byteReader, freq, marshaller, w)
+
+	if err != nil {
+		log.Println("An Error occured when minifying")
+	}
 }
 
 func StreamToByte(stream io.Reader) []byte {


### PR DESCRIPTION
Hey there.
As I use this tool as an internal technical service to parse demos only, I often don't want to use this tool as a CLI, but as a WebServer instead.

So, I made a webserver, which accepts all params as x-headers (don't know if this API is a good solution). The Server then responds with the JSON. Only JSON is supported for now, but I think its easy to add the other types.

As I buffer the whole File to RAM, there maybe is a much better solution. But it works for now.

If you think this is not the responsibilty of this library its okay and just decline this PR.

TODOS
- [x] Update docs
- [x] Implement Server
- [ ] Get feature request accepted